### PR TITLE
36 flexible naming convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Error handling for STIG ID mismatches during checklist upgrade: user is now warned if the old and new STIG IDs do not match, with a detailed message and the option to proceed or cancel.
 - GUI now displays a confirmation dialog for STIG ID mismatches instead of freezing or failing silently.
 - CLI supports a `--force` flag to override STIG ID mismatches without prompting.
+- Prefix override in batch checklist upgrades now only renames checklists that are missing host_name data. All other checklists retain their original host_name as the prefix. This prevents unintended renaming of all files in a batch when only some lack host metadata.
 
 ### Fixed
 - Prevented GUI freeze when merging checklists with mismatched STIG IDs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [v2.0.1] - 2025-05-22
+### Added
+- Error handling for STIG ID mismatches during checklist upgrade: user is now warned if the old and new STIG IDs do not match, with a detailed message and the option to proceed or cancel.
+- GUI now displays a confirmation dialog for STIG ID mismatches instead of freezing or failing silently.
+- CLI supports a `--force` flag to override STIG ID mismatches without prompting.
+
+### Fixed
+- Prevented GUI freeze when merging checklists with mismatched STIG IDs.
+- Improved merge workflow to ensure checklists are created or updated only after user confirmation on mismatches.
+
+### Changed
+- Refactored merge logic to allow both CLI and GUI to handle user confirmation appropriately.
+
 ## [v2.0.0] - 2025-05-20
 ### Added
 - Major GUI redesign: modern, aligned, and user-friendly layout for checklist merging and downloads

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ See the full license text here: [CC BY-NC 4.0](https://creativecommons.org/licen
     ```
     - On Windows, activate with:
       ```cmd
+      python -m venv stigvenv
       stigvenv\Scripts\activate
       ```
 

--- a/gui.py
+++ b/gui.py
@@ -28,6 +28,16 @@ def log_job_status(message):
     log_output.configure(state="disabled")
 
 # === Modified Button Commands with Feedback ===
+def get_internal_mode(mode_label):
+    mapping = {
+        "SCAP Benchmarks": "benchmark",
+        "Operating Systems": "checklist",
+        "Applications": "application",
+        "Network": "network",
+        "ALL": "all"
+    }
+    return mapping.get(mode_label, "benchmark")
+
 def run_generate_baseline_with_feedback():
     log_job_status("[INFO] Job started: Generating new baseline...")
     def on_status_update(status):
@@ -37,7 +47,7 @@ def run_generate_baseline_with_feedback():
         elif status.startswith("Error"):
             log_job_status(f"[ERROR] {status}")
     run_generate_baseline_task(
-        mode=mode_var.get(),
+        mode=get_internal_mode(mode_var.get()),
         headful=headful_var.get(),
         on_status_update=on_status_update,
         clear_log=lambda: log_output.delete(1.0, tk.END)
@@ -57,7 +67,7 @@ def run_compare_with_feedback():
         elif status.startswith("Error"):
             log_job_status(f"[ERROR] {status}")
     run_compare_task(
-        mode=mode_var.get(),
+        mode=get_internal_mode(mode_var.get()),
         headful=headful_var.get(),
         baseline_path=yaml_path_var.get(),
         download_updates_checked=download_var.get(),
@@ -248,7 +258,7 @@ root.configure(bg="#f7fafd")
 #        pass
 
 # === Variables (must be defined before layout) ===
-mode_var = tk.StringVar(value="benchmark")
+mode_var = tk.StringVar(value="Operating Systems")
 headful_var = tk.BooleanVar()
 yaml_path_var = tk.StringVar()
 status_text = tk.StringVar(value="Ready")
@@ -351,7 +361,7 @@ top_controls.grid(row=0, column=1, columnspan=2, sticky="nsew", pady=(0, 18), pa
 # Use a single grid for all controls in top_controls for perfect alignment
 scrape_label = ttk.Label(top_controls, text="Scrape Mode:", font=LABEL_FONT)
 scrape_label.grid(row=0, column=0, padx=(0, 10), pady=4, sticky="w")
-scrape_combo = ttk.Combobox(top_controls, textvariable=mode_var, values=["benchmark", "checklist", "application", "network", "all"], state="readonly", width=15)
+scrape_combo = ttk.Combobox(top_controls, textvariable=mode_var, values=["SCAP Benchmarks", "Operating Systems", "Applications", "Network", "ALL"], state="readonly", width=15)
 scrape_combo.grid(row=0, column=1, padx=(0, 10), pady=4, sticky="ew")
 headful_cb = ttk.Checkbutton(top_controls, text="Headful Browser", variable=headful_var)
 headful_cb.grid(row=0, column=2, padx=(0, 10), pady=4, sticky="w")

--- a/gui.py
+++ b/gui.py
@@ -431,6 +431,15 @@ def update_now_handler():
         tk.messagebox.showerror("Error", f"Failed to check STIG IDs: {e}")
         return
 
+    # Prompt for optional prefix override
+    prefix = None
+    def set_prefix():
+        nonlocal prefix
+        prefix = tk.simpledialog.askstring("Prefix Override", "Enter host-name prefix (leave blank for auto):")
+        if prefix == '':
+            prefix = None
+    set_prefix()
+
     log_job_status("[INFO] Job started: Merging/updating checklists...")
     merged_results = run_merge_task(
         selected_old_files=selected_old_files,
@@ -438,7 +447,8 @@ def update_now_handler():
         usr_dir=usr_dir,
         cklb_dir=cklb_dir,
         on_status_update=status_text.set,
-        force=force_merge
+        force=force_merge,
+        prefix=prefix
     )
     for result in merged_results:
         if result["new_rules"]:

--- a/gui.py
+++ b/gui.py
@@ -351,7 +351,7 @@ getting_started.columnconfigure(0, weight=1)
 getting_started.rowconfigure(0, weight=1)
 
 # Example content for Getting Started (customize as needed)
-ttks = ttk.Label(getting_started, text="1. Create & Customize Baseline.\n2. Set Custom Baseline. (Used to compare your version against published versions.)\n3. Import completed cklb.\n4. Select task options and Run Tasks. (Ensure correct mode selected for selected baseline.) \n \nWhen creating your first baseline, CheckMate uses the current release and version info \nfrom the DISA website. This may not align with your current cklbs. Edit the baseline \nto match that of your current cklbs, ex:RHEL8_v1r2.", font=LABEL_FONT, background=SECTION_BG, justify="left", anchor="nw")
+ttks = ttk.Label(getting_started, text="1. Create & Customize Baseline.\n2. Set Custom Baseline. (Used to compare your version against published versions.)\n3. Import completed cklb.\n4. Select task options and Run Tasks. (Ensure correct mode selected for selected baseline.) \n\nIMPORTANT:\nWhen creating your first baseline, CheckMate uses the current release and version info \nfrom the DISA website. This may not align with your current cklbs. Edit the baseline \nto match that of your version release, ex:RHEL8_v1r2.\nBaselines and Scrape Mode misuse are the most common cause of download failures.", font=LABEL_FONT, background=SECTION_BG, justify="left", anchor="nw")
 ttks.grid(row=0, column=0, sticky="nw", padx=0, pady=0)
 
 # === Top Controls Group ===

--- a/handlers.py
+++ b/handlers.py
@@ -95,7 +95,7 @@ def run_compare_task(mode, headful, baseline_path, download_updates_checked, ext
             on_status_update("Error. Check log output.")
     threading.Thread(target=task).start()
 
-def run_merge_task(selected_old_files, new_name, usr_dir, cklb_dir, on_status_update, force=False):
+def run_merge_task(selected_old_files, new_name, usr_dir, cklb_dir, on_status_update, force=False, prefix=None):
     if not selected_old_files or not new_name:
         on_status_update("Select at least one old and one new CKLB file.")
         return []
@@ -110,11 +110,24 @@ def run_merge_task(selected_old_files, new_name, usr_dir, cklb_dir, on_status_up
 
         with open(old_path, "r", encoding="utf-8") as f:
             old_json = json.load(f)
-        host_prefix = old_json.get("target_data", {}).get("host_name", "HOSTNAME_MISSING")
-        merged_name = f"{host_prefix}_{new_name}"
+        # Determine host_prefix with override and fallback
+        host_prefix = prefix or old_json.get("target_data", {}).get("host_name")
+        if not host_prefix:
+            host_prefix = os.path.splitext(os.path.basename(old_name))[0]
+            logging.warning(f"No host_name in {old_name} – using '{host_prefix}' as prefix")
+        # Guarantee uniqueness
+        base = f"{host_prefix}_{new_name}"
+        out_name = base
+        counter = 1
+        while os.path.exists(os.path.join(out_dir, out_name)):
+            out_name = f"{base}_{counter}"
+            counter += 1
+        merged_name = out_name
         out_path = os.path.join(out_dir, merged_name)
 
         cmd = [sys.executable, os.path.join(os.getcwd(), 'selected_merger.py'), old_path, new_path, '-o', out_path]
+        if prefix:
+            cmd.extend(['--prefix', prefix])
         if force:
             cmd.append('--force')
         try:

--- a/handlers.py
+++ b/handlers.py
@@ -69,20 +69,23 @@ def run_compare_task(mode, headful, baseline_path, download_updates_checked, ext
                     for item in changed_items:
                         zip_name = os.path.basename(item.get("URL", ""))
                         zip_path = os.path.join(zip_dir, zip_name)
-                        xccdf_path = extract_xccdf_from_zip(zip_path, zip_dir)
+                        xccdf_paths = extract_xccdf_from_zip(zip_path, zip_dir)
 
-                        if xccdf_path:
-                            try:
-                                cklb_json = generate_cklb_json(xccdf_path)
-                                basename = os.path.basename(xccdf_path).replace("-xccdf.xml", "").replace("Manual", "").strip("_- ")
-                                date_str = datetime.today().strftime("%Y%m%d")
-                                outfile_name = f"{basename}_{date_str}.cklb"
-                                outfile = os.path.join(out_dir, outfile_name)
-                                with open(outfile, 'w') as f:
-                                    json.dump(cklb_json, f, indent=2)
-                                logging.info(f"Generated checklist: {outfile}")
-                            except Exception as e:
-                                logging.error(f"Failed to generate checklist from {xccdf_path}: {e}")
+                        if xccdf_paths:
+                            if not isinstance(xccdf_paths, list):
+                                xccdf_paths = [xccdf_paths]
+                            for xccdf_path in xccdf_paths:
+                                try:
+                                    cklb_json = generate_cklb_json(xccdf_path)
+                                    basename = os.path.basename(xccdf_path).replace("-xccdf.xml", "").replace("Manual", "").strip("_- ")
+                                    date_str = datetime.today().strftime("%Y%m%d")
+                                    outfile_name = f"{basename}_{date_str}.cklb"
+                                    outfile = os.path.join(out_dir, outfile_name)
+                                    with open(outfile, 'w') as f:
+                                        json.dump(cklb_json, f, indent=2)
+                                    logging.info(f"Generated checklist: {outfile}")
+                                except Exception as e:
+                                    logging.error(f"Failed to generate checklist from {xccdf_path}: {e}")
 
             on_status_update("Done")
             if on_cklb_refresh:

--- a/scraper.py
+++ b/scraper.py
@@ -2,6 +2,7 @@ import logging
 from playwright.sync_api import sync_playwright
 import re
 
+
 # === Constants ===
 SCAP_URL = "https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=scap"
 OS_URL = "https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems"

--- a/xccdf_extractor.py
+++ b/xccdf_extractor.py
@@ -19,18 +19,17 @@ def extract_xccdf_from_zip(zip_path: str, output_dir: str = "cklb_proc/xccdf_lib
                 logging.warning(f"No '-xccdf.xml' file found in {zip_path}")
                 return None
 
-            xccdf_file = matching[0]
-            logging.info(f"Extracting {xccdf_file} from {os.path.basename(zip_path)}")
-
-            # Flatten the path
-            with zf.open(xccdf_file) as source, open(os.path.join(output_dir, os.path.basename(xccdf_file)), 'wb') as target:
-                target.write(source.read())
-
-            extracted_path = os.path.join(output_dir, os.path.basename(xccdf_file))
+            extracted_paths = []
+            for xccdf_file in matching:
+                logging.info(f"Extracting {xccdf_file} from {os.path.basename(zip_path)}")
+                out_path = os.path.join(output_dir, os.path.basename(xccdf_file))
+                with zf.open(xccdf_file) as source, open(out_path, 'wb') as target:
+                    target.write(source.read())
+                extracted_paths.append(out_path)
 
         os.remove(zip_path)
         logging.info(f"Deleted original ZIP: {os.path.basename(zip_path)}")
-        return extracted_path
+        return extracted_paths
     except Exception as e:
         logging.error(f"Failed to extract XCCDF from {zip_path}: {e}")
         return None


### PR DESCRIPTION
refix override in batch checklist upgrades now only renames checklists that are missing host_name data. All other checklists retain their original host_name as the prefix. This prevents unintended renaming of all files in a batch when only some lack host metadata.